### PR TITLE
Fix missing prefix handling in trie

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,8 +16,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install pylint
+        python -m pip install --upgrade pip setuptools pylint
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(here / "README.md", encoding="utf-8") as fh:
 
 setup(
     name="prefix_tree",
-    version="0.0.8",
+    version="0.0.9",
     author="ice1x",
     author_email="ice2600x@gmale.com",
     description="A pure Python prefix tree (trie) for fast in-memory prefix search and filtering",

--- a/src/prefix_tree/trie.py
+++ b/src/prefix_tree/trie.py
@@ -55,15 +55,15 @@ class Trie(Node):
         Return:
             node(Node)
         """
-        node = self
-        if not node.children:
-            return None
+        if prefix == self.char:
+            return self
 
+        node = self
         for char in prefix:
-            if node.children.get(char):
-                node = node.children.get(char)
+            if char in node.children:
+                node = node.children[char]
             else:
-                break
+                return None
         return node
 
     def _get_data_by_child(self, parent: Node, result: str) -> str:
@@ -90,6 +90,8 @@ class Trie(Node):
             (list): list of dict"s
         """
         node = self._get_last_node_by_prefix(prefix)
+        if node is None:
+            return []
         return self._get_data_by_child(node, node.data)
 
     def get_by_prefix_sort_desc_by(self, prefix: str, key_: str) -> list:
@@ -134,7 +136,10 @@ class Trie(Node):
         Return:
             (dict or None):
         """
-        for i in self._get_last_node_by_prefix(word).data:
+        node = self._get_last_node_by_prefix(word)
+        if node is None:
+            return None
+        for i in node.data:
             for j in query.items():
                 if j not in i.items():
                     break

--- a/tests/test.py
+++ b/tests/test.py
@@ -86,6 +86,16 @@ class TestTrieMethods(unittest.TestCase):  # pylint: disable=C0115
         res = self.trie.get_by_prefix_and_query("и", {"type": True, "gender": False})
         self.assertEqual(res, [IRINA_23_FT])
 
+    def test_get_by_prefix_not_found(self):
+        """Prefix not found should return empty list"""
+        res = self.trie._get_by_prefix('неизвестно')  # pylint: disable=W0212
+        self.assertEqual(res, [])
+
+    def test_get_by_word_and_query_not_found(self):
+        """Word not found should return None"""
+        res = self.trie.get_by_word_and_query('неизвестно', {"type": True})
+        self.assertIsNone(res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `_get_last_node_by_prefix` returns `None` when a prefix is not present
- propagate `None` handling through `_get_by_prefix` and `get_by_word_and_query`
- add regression tests for missing prefixes and words

## Testing
- `pytest tests/test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68713b9d542883298e2f743d9b331eb4